### PR TITLE
Speedup rows display table

### DIFF
--- a/src/rowsdisplaytable.tsx
+++ b/src/rowsdisplaytable.tsx
@@ -42,7 +42,6 @@ export class RowsDisplayTable extends React.Component<HiPlotPluginData, RowsDisp
     table_ref: React.RefObject<HTMLTableElement> = React.createRef();
     table_container: React.RefObject<HTMLDivElement> = React.createRef();
     dt = null;
-    dom: JQuery;
     ordered_cols: Array<string> = [];
     empty: boolean;
 
@@ -59,7 +58,7 @@ export class RowsDisplayTable extends React.Component<HiPlotPluginData, RowsDisp
         if (!this.props.params_def["uid"]) {
             return;
         }
-        this.dom = $(this.table_ref.current);
+        const dom = $(this.table_ref.current);
         this.ordered_cols = ['', 'uid'];
         const me = this;
         $.each(this.props.params_def, function(k: string, def) {
@@ -68,7 +67,7 @@ export class RowsDisplayTable extends React.Component<HiPlotPluginData, RowsDisp
             }
             me.ordered_cols.push(k);
         });
-        this.dom.empty();
+        dom.empty();
         var columns: Array<{[k: string]: any}> = this.ordered_cols.map(function(x) {
             const pd = me.props.params_def[x];
             return {
@@ -85,7 +84,7 @@ export class RowsDisplayTable extends React.Component<HiPlotPluginData, RowsDisp
             const color = me.props.get_color_for_row(me.props.dp_lookup[row[individualUidColIdx]], 1.0);
             return `<span class="${style.colorBlock}" style="background-color: ${color}" />`;
         };
-        this.dt = this.dom.DataTable({
+        this.dt = dom.DataTable({
             columns: columns,
             data: [],
             deferRender: true, // Create HTML elements only when displayed
@@ -116,7 +115,7 @@ export class RowsDisplayTable extends React.Component<HiPlotPluginData, RowsDisp
         btnsContainer.addClass("btn-group");
         this.dt.buttons().container().appendTo(btnsContainer);
         btnsContainer.find(".dt-buttons").removeClass("btn-group");
-        this.dom.on( 'search.dt', function (this: RowsDisplayTable) {
+        dom.on( 'search.dt', function (this: RowsDisplayTable) {
             if (!this.dt) {
                 return;
             }
@@ -130,7 +129,7 @@ export class RowsDisplayTable extends React.Component<HiPlotPluginData, RowsDisp
         }.bind(this));
 
         this.empty = true;
-        this.dom.find('tbody')
+        dom.find('tbody')
             .on('mouseenter', 'td', function () {
                 if (!me.dt || me.empty) {
                     return;
@@ -139,7 +138,7 @@ export class RowsDisplayTable extends React.Component<HiPlotPluginData, RowsDisp
                 const row = me.dt.row(rowIdx);
                 const individualUidColIdx = me.dt.colReorder.order().indexOf(1);
 
-                $(me.dt.cells().nodes()).removeClass(style.highlight);
+                dom.find(`.${style.highlight}`).removeClass(style.highlight);
                 $(row.nodes()).addClass(style.highlight);
                 me.props.setHighlighted([me.props.dp_lookup[row.data()[individualUidColIdx]]]);
             })
@@ -155,12 +154,42 @@ export class RowsDisplayTable extends React.Component<HiPlotPluginData, RowsDisp
         me.setSelected(me.props.rows_selected);
     }
     componentDidUpdate(prevProps: HiPlotPluginData): void {
+        /* Sometimes we need to redraw the entire table
+         * but this is super expensive, so let's do it only if
+         * strictly necessary
+         * aka when changing `numeric` status of a column
+         * or when we add/remove columns
+         */
+        var shouldRemountTable = false;
         if (prevProps.params_def != this.props.params_def) {
+            const k1: string[] = Object.keys(prevProps.params_def);
+            const k2: string[] = Object.keys(this.props.params_def);
+            k1.sort();
+            k2.sort();
+            if (k1.length != k2.length) {
+                shouldRemountTable = true;
+            }
+            else {
+                for (var i = 0; i < k1.length; ++i) {
+                    if (k1[i] != k2[i] ||
+                            prevProps.params_def[k1[i]].numeric != this.props.params_def[k2[i]].numeric) {
+                        shouldRemountTable = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if (shouldRemountTable) {
             this.destroyDt();
             this.mountDt();
         }
-        else if (prevProps.rows_selected != this.props.rows_selected ||
-                prevProps.colorby != this.props.colorby) {
+        else if (// Rows changed
+                prevProps.rows_selected != this.props.rows_selected ||
+                // Color changed - need redraw with the correct color
+                prevProps.colorby != this.props.colorby ||
+                // Color scale changed - need redraw with the correct color
+                prevProps.params_def != this.props.params_def
+        ) {
             this.setSelected_debounced(this.props.rows_selected);
         }
     }
@@ -193,12 +222,21 @@ export class RowsDisplayTable extends React.Component<HiPlotPluginData, RowsDisp
             return;
         }
         const ordered_cols = this.ordered_cols;
+        const ock = dt.colReorder.transpose([...Array(ordered_cols.length).keys()]);
 
         dt.clear();
         dt.rows.add(selected.map(function(row) {
-            return dt.colReorder.transpose([...Array(ordered_cols.length).keys()]).map(x => x == '' ? '' : row[ordered_cols[x]]);
+            return ock.map(x => x == '' ? '' : row[ordered_cols[x]]);
         }));
-        dt.draw();
+        if (dt.search() == "") {
+            // Hack to redraw faster
+            dt.settings()[0].oFeatures.bFilter = false;
+            dt.draw();
+            dt.settings()[0].oFeatures.bFilter = true;
+        }
+        else {
+            dt.draw();
+        }
         this.empty = selected.length == 0;
     }
     render() {


### PR DESCRIPTION
Especially useful when dealing with a very large number of rows (50.000+).
Table refresh is triggered regularly when slicing on the parallel plot, and when it's slow, the interface feels laggy