### PR TITLE
Disable dark theme by default

### DIFF
--- a/hiplot/experiment.py
+++ b/hiplot/experiment.py
@@ -215,7 +215,7 @@ class Experiment(_DictSerializable):
         validate_colormap(self.colormap)
         return self
 
-    def display(self, force_full_width: bool = False, store_state_key: Optional[str] = None) -> "ExperimentDisplayed":
+    def display(self, force_full_width: bool = False, store_state_key: Optional[str] = None, **kwargs: Any) -> "ExperimentDisplayed":
         """
         Displays an experiment in an ipython notebook.
 
@@ -230,9 +230,9 @@ class Experiment(_DictSerializable):
         from .ipython import display_exp  # pylint: disable=cyclic-import
 
         self.validate()
-        return display_exp(self, force_full_width=force_full_width, store_state_url=store_state_key)
+        return display_exp(self, force_full_width=force_full_width, store_state_url=store_state_key, **kwargs)
 
-    def to_html(self, file: Optional[Union[Path, str, IO[str]]] = None) -> str:
+    def to_html(self, file: Optional[Union[Path, str, IO[str]]] = None, **kwargs: Any) -> str:
         """
         Returns the content of a standalone .html file that displays this experiment
         without any dependency to HiPlot server or static files.
@@ -242,6 +242,7 @@ class Experiment(_DictSerializable):
         """
         self.validate()
         html = make_experiment_standalone_page(options={
+            **kwargs,
             'experiment': self._asdict()
         })
         html = html_inlinize(html)

--- a/hiplot/ipython.py
+++ b/hiplot/ipython.py
@@ -110,11 +110,13 @@ class IPythonExperimentDisplayed(exp.ExperimentDisplayed):
 def display_exp(
         xp: exp.Experiment,
         force_full_width: bool = False,
-        store_state_url: t.Optional[str] = None
+        store_state_url: t.Optional[str] = None,
+        **kwargs: t.Any
 ) -> IPythonExperimentDisplayed:
     comm_id = f"comm_{uuid.uuid4().hex[:6]}"
     displayed_xp = IPythonExperimentDisplayed(xp, comm_id)
     options: t.Dict[str, t.Any] = {
+        **kwargs,
         'experiment': xp._asdict()
     }
     if store_state_url is not None:

--- a/src/hiplot.tsx
+++ b/src/hiplot.tsx
@@ -122,7 +122,7 @@ export class HiPlot extends React.Component<HiPlotProps, HiPlotState> {
     static defaultProps = {
         is_webserver: false,
         comm: null,
-        dark: null,
+        dark: false,
         asserts: false,
     };
     static getDerivedStateFromError(error: Error) {


### PR DESCRIPTION
Has to be enabled manually (aka `exp.display(dark=True)`, or with auto-detect `exp.display(dark=None)`) - still very experimental and subject to changes