### PR TITLE
Fixed crashes when there are NaN values in dataframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # HiPlot - High dimensional Interactive Plotting [![CircleCI](https://circleci.com/gh/facebookresearch/hiplot/tree/master.svg?style=svg&circle-token=c89b6825078e174cf35bdc18e4ad4a16e28876f9)](https://circleci.com/gh/facebookresearch/hiplot/tree/master)
 
 
-![Logo](https://raw.githubusercontent.com/facebookresearch/hiplot/master/hiplot/static/logo.png)
+![Logo](https://raw.githubusercontent.com/facebookresearch/hiplot/master/hiplot/static/logo.png) 
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/facebookresearch/hiplot/blob/master/examples/HiPlotColabExample.ipynb)
 
 
 HiPlot is a lightweight interactive visualization tool to help AI researchers discover correlations and patterns in high-dimensional data using parallel plots and other graphical ways to represent information.
 
-### [Try a demo now with sweep data](https://facebookresearch.github.io/hiplot/_static/demo/ml1.csv.html) or [upload your CSV](https://facebookresearch.github.io/hiplot/_static/hiplot_upload.html)
+### [Try a demo now with sweep data](https://facebookresearch.github.io/hiplot/_static/demo/ml1.csv.html) or [upload your CSV](https://facebookresearch.github.io/hiplot/_static/hiplot_upload.html)  or [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/facebookresearch/hiplot/blob/master/examples/HiPlotColabExample.ipynb)
 
 There are several modes to HiPlot:
 - As a web-server (if your data is a CSV for instance)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 ![Logo](https://raw.githubusercontent.com/facebookresearch/hiplot/master/hiplot/static/logo.png)
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 
 HiPlot is a lightweight interactive visualization tool to help AI researchers discover correlations and patterns in high-dimensional data using parallel plots and other graphical ways to represent information.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ![Logo](https://raw.githubusercontent.com/facebookresearch/hiplot/master/hiplot/static/logo.png) 
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/facebookresearch/hiplot/blob/master/examples/HiPlotColabExample.ipynb)
+[![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/facebookresearch/hiplot/blob/master/examples/HiPlotColabExample.ipynb)
 
 
 HiPlot is a lightweight interactive visualization tool to help AI researchers discover correlations and patterns in high-dimensional data using parallel plots and other graphical ways to represent information.

--- a/hiplot/experiment.py
+++ b/hiplot/experiment.py
@@ -485,6 +485,8 @@ To render an experiment to HTML, use `experiment.to_html(file_name)` or `html_pa
 
         :param dataframe: Pandas DataFrame
         """
+
+        dataframe.fillna('', inplace=True)
         return Experiment.from_iterable(dataframe.to_dict(orient='records'))
 
     @staticmethod

--- a/hiplot/experiment.py
+++ b/hiplot/experiment.py
@@ -486,7 +486,7 @@ To render an experiment to HTML, use `experiment.to_html(file_name)` or `html_pa
         :param dataframe: Pandas DataFrame
         """
 
-        dataframe.fillna('', inplace=True)
+        dataframe = dataframe.fillna({'from_uid': '', 'uid': ''})
         return Experiment.from_iterable(dataframe.to_dict(orient='records'))
 
     @staticmethod

--- a/hiplot/experiment.py
+++ b/hiplot/experiment.py
@@ -485,8 +485,20 @@ To render an experiment to HTML, use `experiment.to_html(file_name)` or `html_pa
 
         :param dataframe: Pandas DataFrame
         """
+        # Check if from_uid and uid is both in columns
+        if {'from_uid', 'uid'}.issubset(dataframe.columns):
+            # Check if there are any NaN values to handle
+            if dataframe['from_uid'].isnull().values.any():
 
-        dataframe = dataframe.fillna({'from_uid': '', 'uid': ''})
+                # NaN values forces integer columns to become float, if uid is integer and from_uid is float, it crashes.
+                # The line below changes uid to match from_uid type (either float or string), since NaN cannot be integer. 
+                dataframe['uid']= dataframe['uid'].astype(dataframe['from_uid'].dtypes)
+                dataframe = dataframe.fillna({'from_uid': '', 'uid': ''})
+
+                # Replaces their dtypes accordingly to str, which is handled better with lesser errors with no change to functionality
+                dataframe['uid']= dataframe['uid'].astype(str)
+                dataframe['from_uid']= dataframe['from_uid'].astype(str)
+
         return Experiment.from_iterable(dataframe.to_dict(orient='records'))
 
     @staticmethod

--- a/hiplot/test_experiment.py
+++ b/hiplot/test_experiment.py
@@ -36,6 +36,26 @@ def test_from_dataframe() -> None:
     xp.validate()
     xp._asdict()
 
+def test_from_dataframe_nan_values() -> None:
+    # Pandas automatically convert numeric-based columns None to NaN in dataframes
+    # Pandas will also automatically convert columns with NaN from integer to floats, since NaN is considered a float
+    # https://pandas.pydata.org/pandas-docs/stable/user_guide/integer_na.html
+
+    df = pd.DataFrame(data={'uid':[1,2,3,4],'from_uid':[None,1,2,3],'a':[1,2,3,None],'b':[4,5,None,6]})
+    xp = hip.Experiment.from_dataframe(df)
+    assert len(xp.datapoints) == 4
+    xp.validate()
+    xp._asdict()
+
+def test_from_dataframe_none_values() -> None:
+    # Pandas will keep None values in string columns
+    df = pd.DataFrame(data={'uid':["1","2","3","4"],'from_uid':[None,"1","2","3"],'a':[23,43,5,None],'b':[33,45,None,23]})
+    xp = hip.Experiment.from_dataframe(df)
+    assert len(xp.datapoints) == 4
+    xp.validate()
+    xp._asdict()
+
+
 
 def test_validation() -> None:
     with pytest.raises(hip.ExperimentValidationError):

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,3 +10,4 @@ guzzle_sphinx_theme
 pre-commit
 pandas
 streamlit>=0.63
+beautifulsoup4


### PR DESCRIPTION
Currently, a common way to read csv files (from kaggle, etc) to dataframe is using the below code

```python
df = pd.read_csv("example.csv")
hip.Experiment.from_dataframe(df).display()
```
which replaces empty string with NaN, which crashes when the second line is run.

A workaround used in the colab notebook was
```python
df = pd.read_csv("example.csv", keep_default_na=False)
hip.Experiment.from_dataframe(df).display()
```

I propose a change in the from_dataframe code such that it automatically replace NaN back with empty strings, so that it will be coerced into null by the from_dict code.

I can change back the colab notebook example to the first codeblock once the latest version of HiPlot rolls out with the fix!
