### PR TITLE
Disable option 'force_full_width' on Jupyter lab

### DIFF
--- a/hiplot/fetchers.py
+++ b/hiplot/fetchers.py
@@ -267,6 +267,8 @@ load_wav2letter = Wav2letterLoader()
 
 def _get_module_by_name_in_cwd(name: str) -> tp.Any:
     spec = importlib.util.spec_from_file_location(name, str(Path(os.getcwd()) / f"{name}.py"))
+    if spec is None:
+        return None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)  # type: ignore
     return module
@@ -280,6 +282,8 @@ def get_fetcher(fetcher_spec: str) -> hip.ExperimentFetcher:
         if len(parts) != 2:
             raise
         module = _get_module_by_name_in_cwd(parts[0])
+    if module is None:
+        raise RuntimeError(f"Unable to create fetcher '{fetcher_spec}'")
 
     return getattr(module, parts[-1])  # type: ignore
 

--- a/hiplot/ipython.py
+++ b/hiplot/ipython.py
@@ -43,6 +43,12 @@ def jupyter_make_full_width(content: str) -> str:
 <script type="text/javascript">
 (function() {{
     const elem = document.getElementById({json.dumps(w_id)});
+    try {{
+        Jupyter.notebook.kernel; // `Jupyter` is not defined on Labs
+    }} catch(err) {{
+        console.warn('Option "force_full_width" is only supported on Jupyter Notebooks (Labs is not supported as the display area is larger)');
+        return;
+    }}
     elem.style.width = "100vw";
     const removeElems = elem.parentElement.parentElement.getElementsByClassName("prompt");
     for (var i = 0; i < removeElems.length; ++i) {{


### PR DESCRIPTION
Fixes #16


**TEST PLAN:**
On Jupyter Notebook:
![image](https://user-images.githubusercontent.com/43445237/121861533-2c2d7900-ccfa-11eb-900b-550ec133a262.png)

On Jupyter Labs:
![image](https://user-images.githubusercontent.com/43445237/121861609-3ea7b280-ccfa-11eb-9c2a-380f2cf07966.png)

