### PR TITLE
Error Checking for Optuna Integration

### DIFF
--- a/hiplot/experiment.py
+++ b/hiplot/experiment.py
@@ -515,9 +515,10 @@ To render an experiment to HTML, use `experiment.to_html(file_name)` or `html_pa
 
         # Create a list of dictionary objects using study trials
         # All parameters are taken using params.copy()
-
+        import optuna
+        
         hyper_opt_data = []
-        for each_trial in study.trials:
+        for each_trial in study.get_trials(states=(optuna.trial.TrialState.COMPLETE, )):
             trial_params = {}
             if not each_trial.values: # This checks if the trial was fully completed - the value will be None if the trial was interrupted halfway (e.g. via KeyboardInterrupt)
                 continue


### PR DESCRIPTION
Added code to skip over KeyboardInterrupted trials

Just a little bit of mistake on my end - forgot to error-check if trials were interrupted halfway by the user

![image](https://user-images.githubusercontent.com/42860714/138552333-8f374354-d02b-455d-a38c-4cacce077364.png)
