### PR TITLE
Hack-fix labels on safari when scrolling

### DIFF
--- a/src/component.tsx
+++ b/src/component.tsx
@@ -21,7 +21,7 @@ import { ErrorDisplay, HeaderBar } from "./header";
 import { HiPlotPluginData, DataProviderClass } from "./plugin";
 import { StaticDataProvider } from "./dataproviders/static";
 import { uncompress } from "./lib/compress";
-
+import { setupBrowserCompat } from "./lib/browsercompat";
 
 //@ts-ignore
 import LogoSVG from "../hiplot/static/logo.svg";
@@ -152,6 +152,7 @@ export function createDefaultPlugins(): PluginsMap {
 export class HiPlot extends React.Component<HiPlotProps, HiPlotState> {
     // React refs
     contextMenuRef = React.createRef<ContextMenu>();
+    rootRef = React.createRef<HTMLDivElement>();
 
     plugins_window_state: {[plugin: string]: any} = {};
 
@@ -322,6 +323,8 @@ export class HiPlot extends React.Component<HiPlotProps, HiPlotState> {
         this.callFilteredUidsHooks.cancel();
     }
     componentDidMount() {
+        setupBrowserCompat(this.rootRef.current);
+
         // Setup contextmenu when we right-click a parameter
         this.contextMenuRef.current.addCallback(this.columnContextMenu.bind(this), this);
 
@@ -532,7 +535,7 @@ export class HiPlot extends React.Component<HiPlotProps, HiPlotState> {
             };
         }.bind(this);
         return (
-        <div className={`hip_thm--${this.state.dark ? "dark" : "light"}`}>
+        <div ref={this.rootRef} className={`hip_thm--${this.state.dark ? "dark" : "light"}`}>
             <div className={style.hiplot}>
             <SelectedCountProgressBar {...controlProps} />
             <HeaderBar

--- a/src/lib/browsercompat.ts
+++ b/src/lib/browsercompat.ts
@@ -1,0 +1,29 @@
+
+export const IS_SAFARI = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
+export function redrawObject(fo: SVGForeignObjectElement) {
+    const parent = fo.parentNode;
+    parent.removeChild(fo);
+    parent.appendChild(fo);
+
+}
+export function redrawAllForeignObjectsIfSafari() {
+    if (!IS_SAFARI) {
+        return;
+    }
+    const fo = document.getElementsByTagName("foreignObject");
+    Array.from(fo).forEach(redrawObject);
+}
+
+export function setupBrowserCompat(root: HTMLDivElement) {
+    /**
+     * Safari has a lot of trouble with foreignObjects inside canvas. Especially when we apply rotations, etc...
+     * As it considers the parent of the objects inside the FO to be the canvas origin, and not the FO.
+     * See https://stackoverflow.com/questions/51313873/svg-foreignobject-not-working-properly-on-safari
+     * Applying the fix in the link above fixes their position upon scroll - we don't want that, so we
+     * manually force-redraw them upon scroll.
+     */
+    if (IS_SAFARI) {
+        root.addEventListener("wheel", redrawAllForeignObjectsIfSafari);
+    }
+}

--- a/src/lib/svghelpers.ts
+++ b/src/lib/svghelpers.ts
@@ -11,6 +11,7 @@ import { ParamDef } from "../infertypes";
 import style from "../hiplot.scss";
 import { ContextMenu } from "../contextmenu";
 
+
 function leftPos(anchor: string, w: number, minmax?: [number, number]): number {
     var left = {
         end: -w,
@@ -51,8 +52,7 @@ export function foCreateAxisLabel(pd: ParamDef, cm?: React.RefObject<ContextMenu
     var fo = document.createElementNS('http://www.w3.org/2000/svg',"foreignObject");
     const span = d3.select(fo).append("xhtml:div")
         .classed(style.tooltipContainer, true)
-        .classed(style.label, true)
-        .style("position", "fixed"); // BUGFIX for transforms in Safari (https://stackoverflow.com/questions/51313873/svg-foreignobject-not-working-properly-on-safari)
+        .classed(style.label, true);
     span.append("xhtml:span")
         .attr("class", pd.label_css)
         .classed("label-name", true)


### PR DESCRIPTION
This is a hackfix, the labels move around a bit when scrolling, but eventually go back to where they should be.
Pending on bug resolution from Safari.

Closes #218